### PR TITLE
Added support for tensor parameters (min/max) to Clip.

### DIFF
--- a/lib/axon_onnx/deserialize.ex
+++ b/lib/axon_onnx/deserialize.ex
@@ -1379,7 +1379,9 @@ defmodule AxonOnnx.Deserialize do
 
         {%Axon{} = inp, %Nx.Tensor{} = min, %Nx.Tensor{} = max} ->
           fun = fn x, params -> Nx.clip(x, params[min_name], params[max_name]) end
-          layer = Axon.layer(inp, fun, %{min_name => min, max_name => max}, output_name, layer_op: :clip)
+          min_param = Axon.param(min_name, Nx.shape(min))
+          max_param = Axon.param(max_name, Nx.shape(max))
+          layer = Axon.layer(inp, fun, %{min_name => min_param, max_name => max_param}, output_name, layer_op: :clip)
           updated_axon = Map.put(axon, output_name, layer)
           updated_params = Map.put(used_params, output_name, %{min_name => min, max_name => max})
           {updated_axon, updated_params}

--- a/lib/axon_onnx/deserialize.ex
+++ b/lib/axon_onnx/deserialize.ex
@@ -1380,10 +1380,12 @@ defmodule AxonOnnx.Deserialize do
 
         {%Axon{} = inp, %Nx.Tensor{} = min, %Nx.Tensor{} = max} ->
           op = fn x, params -> Nx.clip(x, params["min"], params["max"]) end
+
           params = %{
             "min" => Axon.param(min_name, Nx.shape(min)),
             "max" => Axon.param(max_name, Nx.shape(max))
           }
+
           layer = Axon.layer(inp, op, params, output_name, layer_op: :clip)
           updated_axon = Map.put(axon, output_name, layer)
           updated_params = Map.put(used_params, output_name, %{min_name => min, max_name => max})

--- a/lib/axon_onnx/deserialize.ex
+++ b/lib/axon_onnx/deserialize.ex
@@ -1371,6 +1371,12 @@ defmodule AxonOnnx.Deserialize do
           updated_axon = Map.put(axon, output_name, layer)
           {updated_axon, used_params}
 
+        {%Axon{op: :constant, opts: [value: v]} = inp, %Nx.Tensor{} = min, %Nx.Tensor{} = max} ->
+          new_value = Nx.clip(v, min, max)
+          layer = Axon.constant(new_value, name: output_name)
+          updated_axon = Map.put(axon, output_name, layer)
+          {updated_axon, used_params}
+
         {%Axon{} = inp, %Nx.Tensor{} = min, %Nx.Tensor{} = max} ->
           fun = fn x, _params -> Nx.clip(x, min, max) end
           layer = Axon.layer(inp, fun, %{}, output_name, layer_op: :clip)

--- a/lib/axon_onnx/deserialize.ex
+++ b/lib/axon_onnx/deserialize.ex
@@ -1378,10 +1378,12 @@ defmodule AxonOnnx.Deserialize do
           {updated_axon, used_params}
 
         {%Axon{} = inp, %Nx.Tensor{} = min, %Nx.Tensor{} = max} ->
-          fun = fn x, params -> Nx.clip(x, params[min_name], params[max_name]) end
-          min_param = Axon.param(min_name, Nx.shape(min))
-          max_param = Axon.param(max_name, Nx.shape(max))
-          layer = Axon.layer(inp, fun, %{min_name => min_param, max_name => max_param}, output_name, layer_op: :clip)
+          op = fn x, params -> Nx.clip(x, params["min"], params["max"]) end
+          params = %{
+            "min" => Axon.param(min_name, Nx.shape(min)),
+            "max" => Axon.param(max_name, Nx.shape(max))
+          }
+          layer = Axon.layer(inp, op, params, output_name, layer_op: :clip)
           updated_axon = Map.put(axon, output_name, layer)
           updated_params = Map.put(used_params, output_name, %{min_name => min, max_name => max})
           {updated_axon, updated_params}

--- a/lib/axon_onnx/deserialize.ex
+++ b/lib/axon_onnx/deserialize.ex
@@ -1370,6 +1370,12 @@ defmodule AxonOnnx.Deserialize do
           layer = Axon.layer([inp, min, max], fun, %{}, output_name, layer_op: :clip)
           updated_axon = Map.put(axon, output_name, layer)
           {updated_axon, used_params}
+
+        {%Axon{} = inp, %Nx.Tensor{} = min, %Nx.Tensor{} = max} ->
+          fun = fn x, _params -> Nx.clip(x, min, max) end
+          layer = Axon.layer(inp, fun, %{}, output_name, layer_op: :clip)
+          updated_axon = Map.put(axon, output_name, layer)
+          {updated_axon, used_params}
       end
 
     {updated_axon, params, updated_params}


### PR DESCRIPTION
While loading a model (an export of a mobilenet_v3 flavor feature extractor), I got a crash during deserialize for Clip. It appears that the arguments can come in as [tensors of empty shape](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Clip).