### PR TITLE
Support for `op_type` "ConvTranspose"

### DIFF
--- a/lib/axon_onnx/deserialize.ex
+++ b/lib/axon_onnx/deserialize.ex
@@ -1591,6 +1591,22 @@ defmodule AxonOnnx.Deserialize do
     {updated_axon, params, used_params}
   end
 
+  defp recur_nodes(
+    %Node{
+      op_type: "ConvTranspose",
+      input: inputs,
+      attribute: attrs,
+      output: output
+    }, {_axon, params, _used_params}) do
+    # op spec: https://github.com/onnx/onnx/blob/main/docs/Operators.md#convtranspose
+
+    IO.inspect(inputs, label: "inputs")
+    IO.inspect(output, label: "output")
+    IO.inspect(options!(attrs), label: "attrs")
+
+    raise ArgumentError, "unsupported ConvTranspose"
+  end
+
   defp recur_nodes(%Node{op_type: unsupported}, _) do
     raise ArgumentError, "unsupported #{inspect(unsupported)}"
   end


### PR DESCRIPTION
Importing YOLOv6-nano fails with:
```elixir
** (ArgumentError) unsupported "ConvTranspose"
    (axon_onnx 0.1.0) lib/axon_onnx/deserialize.ex:1611: AxonOnnx.Deserialize.recur_nodes/2
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (axon_onnx 0.1.0) lib/axon_onnx/deserialize.ex:44: AxonOnnx.Deserialize.graph_to_axon/2
    (axon_onnx 0.1.0) lib/axon_onnx/deserialize.ex:27: AxonOnnx.Deserialize.to_axon/2
    (stdlib 3.17.1) erl_eval.erl:685: :erl_eval.do_apply/6
    (elixir 1.13.4) lib/code.ex:404: Code.validated_eval_string/3
```
Axon has support for ConvTranspose: https://elixir-nx.github.io/axon/Axon.html#conv_transpose/3
This PR will bridge the gap.