### PR TITLE
Support Nx 0.5 through 0.10, Axon 0.5 through 0.8

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule AxonOnnx.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elixir-nx/axon_onnx"
-  @version "0.4.0"
+  @version "0.5.0"
 
   def project do
     [
@@ -36,11 +36,11 @@ defmodule AxonOnnx.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:axon, "~> 0.5", axon_opts()},
+      {:axon, "~> 0.5 or ~> 0.6 or ~> 0.7 or ~> 0.8", axon_opts()},
       {:protox, "~> 1.6.10"},
-      {:nx, "~> 0.5", nx_opts()},
-      {:exla, "~> 0.5", [only: :test] ++ exla_opts()},
-      {:req, "~> 0.1.0", only: :test},
+      {:nx, "~> 0.5 or ~> 0.6 or ~> 0.7 or ~> 0.8 or ~> 0.9 or ~> 0.10", nx_opts()},
+      {:exla, "~> 0.5 or ~> 0.6 or ~> 0.7 or ~> 0.8 or ~> 0.9 or ~> 0.10", [only: :test] ++ exla_opts()},
+      {:req, "~> 0.3 or ~> 0.4 or ~> 0.5", only: :test},
       {:jason, "~> 1.2", only: :test},
       {:ex_doc, "~> 0.23", only: :docs}
     ]


### PR DESCRIPTION
## Summary

  Widen version constraints to support newer Nx and Axon releases. The existing code (using `deftransformp`) compiles and works fine with Nx 0.10 - only the version constraints in mix.exs were blocking compatibility.

  ## Changes

  - `nx`: `~> 0.5` → `~> 0.5 or ~> 0.6 or ~> 0.7 or ~> 0.8 or ~> 0.9 or ~> 0.10`
  - `axon`: `~> 0.5` → `~> 0.5 or ~> 0.6 or ~> 0.7 or ~> 0.8`
  - `exla`: `~> 0.5` → `~> 0.5 or ... or ~> 0.10` (test only)
  - `req`: `~> 0.1.0` → `~> 0.3 or ~> 0.4 or ~> 0.5` (test only, needed for nimble_pool compatibility)
  - Version bump: `0.4.0` → `0.5.0`

  ## Testing

  Verified compilation with:
  - Nx 0.10.0
  - Axon 0.8.0
  - EXLA 0.10.0

  ## Related

  Fixes: https://elixirforum.com/t/error-using-axononnx-v0-4-0-undefined-function-transform-2/63326